### PR TITLE
Improve test reliability by cleaning the state before running test_remove_missing_module

### DIFF
--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -27,9 +27,12 @@ class Test_operator:
         assert not (cli_UUID in vlx.modules)
 
     def test_remove_missing_module(self):
+        global cli_UUID
+        if cli_UUID in vlx.modules:
+            vlx.remove_module(cli_module)
         with pytest.raises(AttributeError):
             vlx.remove_module(cli_module)
-        vlx.add_module(cli_module)
+        cli_UUID = vlx.add_module(cli_module)
 
     def test_validate_module(self):
         assert vlx.validate_module(vlx) is False


### PR DESCRIPTION
This PR aims to improve reliability of the test `test_remove_missing_module` by cleaning the state before running it.

The test can fail on the second run by running it twice: `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_operator.py::Test_operator::test_remove_missing_module`.
```
    def test_remove_missing_module(self):
        with pytest.raises(AttributeError):
>           vlx.remove_module(cli_module)
E           Failed: DID NOT RAISE <class 'AttributeError'>
```
More specifically, this PR cleans the pre-state by ensuring that the `cli_module` is not in `vlx.modules`. In this way, the test does not fail on the second run any more.