### PR TITLE
Improve test reliability by cleaning the state before running test_add_module

### DIFF
--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -10,6 +10,8 @@ cli_UUID = None
 class Test_operator:
     def test_add_module(self):
         global cli_UUID
+        if cli_UUID in vlx.modules:
+            vlx.remove_module(cli_module)
         cli_UUID = vlx.add_module(cli_module)
         assert cli_UUID in vlx.modules
 


### PR DESCRIPTION
Like https://github.com/DrTexx/Volux/pull/36, this PR aims to improve reliability of the test `test_add_module` by cleaning the state before running it.

The test can fail on the second run by running it twice: `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_operator.py::Test_operator::test_add_module`.
```
    def test_add_module(self):
        global cli_UUID
>       cli_UUID = vlx.add_module(cli_module)

tests/test_operator.py:13
...
>               raise Exception(
                    "this instance of module '{}' is already loaded! [{}{}{}]".format(
                        module._module_name,
                        colorama.Fore.GREEN,
                        module.UUID,
                        colorama.Style.RESET_ALL,
                    )
                )
E               Exception: this instance of module 'Volux CLI Print' is already loaded! [60cf3f79-fe57-4202-b644-7e881da16e12]
volux/operator.py:69: Exception
```
More specifically, this PR cleans the pre-state by ensuring that the `cli_module` is not in `vlx.modules`. In this way, the test does not fail on the second run any more.